### PR TITLE
modifications needed to stand up network_service locally

### DIFF
--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -22,7 +22,7 @@ impl ShardManager {
         let config: toml::Value = toml::from_str(config_str).expect("Failed to parse config");
         let shard_id = config["sharding"]["shard_id"].as_integer().unwrap_or(0) as u32;
         let shard_count = config["sharding"]["shard_count"].as_integer().unwrap_or(1) as u32;
-        let node_map = config["sharding"]["nodes"]
+        let node_map = config["testnet"]["nodes"]
             .as_array()
             .unwrap()
             .iter()


### PR DESCRIPTION
In order to be able to compile and stand up the network_service on my machine I needed to modify a few things.

Keep in mind I'm more of a novice Rust dev. C/C++ and go are my normal environment so this was just a best effort as I'm reading through. Maybe something useful here or possible I'm misinterpretation some things.

1. Needed to make `NetworkService` clone-able in order to satisfy lifetime requirements for tokio async handling.
2. Removed `sv::messages::Hashable` reference which appeared unused.
3. Updated `RateLimiter` template to match compiler requirements.
4. Updated `format` calls to invoke the `format!` macro instead. Didn't see a reference to a format function anywhere that made sense to me.