### PR TITLE
Update README to reflect non consensus readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # 🚀 Galaxy
 **The Ultra High-Performance BSV Node**
 
+***Note: Galaxy is NOT concensus ready. For testing purposes only until release v1.0**
+
 ![Rust](https://img.shields.io/badge/Rust-1.88+-orange?logo=rust)
 ![Build Status](https://github.com/murphsicles/Galaxy/actions/workflows/ci.yml/badge.svg)
 ![Dependencies](https://deps.rs/repo/github/murphsicles/Galaxy/status.svg)
@@ -43,7 +45,7 @@
   - Batching for transactions, blocks, and UTXOs.
   - Lean message structures with 4GB buffer hints for large blocks.
   - Transaction queuing and SPV proof caching.
-  - Scalable UTXO storage with Tiger Beetle DB.
+  - Scalable UTXO storage with Tiger Beetle DB. (Local Hashmap by default).
   - Dynamic chunk sizing for efficient data transfer in torrent-like protocol.
   - Prometheus metrics for performance monitoring.
   - Structured logging with tracing for observability.
@@ -158,7 +160,7 @@ Test services using a TCP client or custom scripts with `bincode` serialization,
 ### Testnet Integration
 Galaxy is configured to connect to BSV testnet nodes. See `tests/config.toml` for settings:
 - Testnet nodes for `network_service`.
-- Tiger Beetle server address for `storage_service`.
+- Tiger Beetle server address for `storage_service`. (Default in memory Hashmap for testing purposes)
 - Sharding parameters and node mappings.
 - Authentication settings.
 - Alert and indexing configurations.


### PR DESCRIPTION
Highlight Galaxy's non readiness for the main branch.
Only official releases should be used for consensus related testing.
Galaxy will only be regarded as "production ready" at release v1.0 